### PR TITLE
Fix csrf token in example

### DIFF
--- a/dio/README.md
+++ b/dio/README.md
@@ -455,7 +455,7 @@ Because of security reasons, we need all the requests to set up a csrfToken in t
 
         final result = await tokenDio.get('/token');
 
-        if (result.hasSucceed) {
+        if (result.statusCode != null && result.statusCode! ~/ 100 == 2) {
           /// assume `token` is in response body
           final body = jsonDecode(result.data) as Map<String, dynamic>?;
 

--- a/example/lib/queued_interceptor_crsftoken.dart
+++ b/example/lib/queued_interceptor_crsftoken.dart
@@ -64,7 +64,8 @@ void main() async {
           /// since the api has no state, force to pass the 401 error
           /// by adding query parameter
           final originResult = await dio.fetch(options..path += '&pass=true');
-          if (originResult.statusCode != null && originResult.statusCode! ~/ 100 == 2) {
+          if (originResult.statusCode != null &&
+              originResult.statusCode! ~/ 100 == 2) {
             return handler.resolve(originResult);
           }
         }


### PR DESCRIPTION
> Picked from https://github.com/flutterchina/dio/pull/1262

## New Pull Request Checklist
* [x]  I have read the [Documentation](https://pub.dartlang.org/packages/dio)
* [x]  I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
* [x]  I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ]  I have added the required tests to prove the fix/feature I am adding
* [x]  I have updated the documentation (if necessary)
* [x]  I have run the tests and they pass

This merge request fixes/refers to the following issues: `example/lib/queued_interceptor_csrftoken.dart`.

## Pull Request Description
### Summary
* added getter methods in the `Response` class for better usage of `statusCode`
* removed callbacks
* replaced callbacks(by using `.then( )` and `.catchError( )`s) with async/await
* reflected the changes in README.md

### Issues
1. in the example(example/lib/queued_interceptor_csrftoken.dart) the `_onResult` method was not being called, since the example baseUrl ('http://www.dtworkroom.com/doris/1/2.0.0/') was not able to run
2. at line 34 in the example, the token is already expired because the status code was 401. And also in `onError` closure, after the token has been updated then the `dio` asks for `fetch` and `resolve` it.
   So I thought the below code might be an extra task because the `dio` will update the token and resolve the request.

```dart
// If the token has been updated, repeat directly.
if (csrfToken != options.headers['csrfToken']) {
  options.headers['csrfToken'] = csrfToken;
  // repeat
  dio.fetch(options).then(
    (r) => handler.resolve(r),
    onError: handler.reject,
  );
  return;
}
```

### Opinion
* for better practice, using async/await can be more helpful than using in a synchronous way

