### PR TITLE
fix(web): fix `Future already completed` error when `connectTimeout` was set

### DIFF
--- a/example_flutter_app/lib/http.dart
+++ b/example_flutter_app/lib/http.dart
@@ -1,3 +1,5 @@
 import 'package:dio/dio.dart';
 
-var dio = Dio();
+var dio = Dio(BaseOptions(
+  connectTimeout: 3000,
+));


### PR DESCRIPTION
> Picked from https://github.com/flutterchina/dio/pull/1550

fix `Future already completed` error when `connectTimeout` was set.

### New Pull Request Checklist
* [x]  I have read the [Documentation](https://pub.dartlang.org/packages/dio)
* [ ]  I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
  * [Fix for "Future already completed" error in web #1496](https://github.com/flutterchina/dio/pull/1496)
  * [Browser adapter time out #1470](https://github.com/flutterchina/dio/pull/1470)
* [x]  I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
* [ ]  I have added the required tests to prove the fix/feature I am adding
* [ ]  I have updated the documentation (if necessary)
* [ ]  I have run the tests and they pass

This merge request fixes / refers to the following issues:

* [[web] Frequent Bad state: Future already completed #1536](https://github.com/flutterchina/dio/issues/1536)
* ["Future already completed" error in web #1497](https://github.com/flutterchina/dio/issues/1497)

### Pull Request Description
Use `Timer` instead of `Future.delay` to implement connectTimeout on Web.