### PR TITLE
Fix `connectTimeout` update gets ignored during runs

### DIFF
--- a/dio/lib/src/adapters/io_adapter.dart
+++ b/dio/lib/src/adapters/io_adapter.dart
@@ -45,7 +45,9 @@ class DefaultHttpClientAdapter implements HttpClientAdapter {
     late HttpClientRequest request;
     try {
       if (options.connectTimeout > 0) {
-        request = await reqFuture.timeout(Duration(milliseconds: options.connectTimeout));
+        request = await reqFuture.timeout(
+          Duration(milliseconds: options.connectTimeout),
+        );
       } else {
         request = await reqFuture;
       }

--- a/dio/test/readtimeout_test.dart
+++ b/dio/test/readtimeout_test.dart
@@ -100,7 +100,6 @@ void main() {
   });
 
   test('#read_timeout - change connectTimeout in run time ', () async {
-
     var dio = Dio();
     final adapter = DefaultHttpClientAdapter();
     final http = HttpClient();
@@ -127,6 +126,5 @@ void main() {
       //ignore
     }
     expect(http.connectionTimeout?.inMilliseconds == 1000, isTrue);
-
   });
 }


### PR DESCRIPTION
> Picked from https://github.com/flutterchina/dio/pull/1513

### New Pull Request Checklist
* [x]  I have read the [Documentation](https://pub.dartlang.org/packages/dio)
* [x]  I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
* [x]  I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
* [x]  I have added the required tests to prove the fix/feature I am adding
* [x]  I have updated the documentation (if necessary)
* [x]  I have run the tests and they pass

### Pull Request Description

When changing the `connectTimeout` during runs, it has been ignored.