### PR TITLE
Fix the problem that the function of forcing the plain text response to json is invalid

### DIFF
--- a/dio/test/mock_adapter.dart
+++ b/dio/test/mock_adapter.dart
@@ -81,6 +81,8 @@ class MockAdapter extends HttpClientAdapter {
               },
             );
           }
+        case '/test-force-convert':
+          return ResponseBody.fromString('{"code":0,"result":"ok"}', 200);
         default:
           return ResponseBody.fromString('', 404);
       }

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -2,10 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 import 'echo_adapter.dart';
+import 'mock_adapter.dart';
 
 void main() {
   test('#test options', () {
@@ -280,5 +283,22 @@ void main() {
     final Response response = await dio.get("");
 
     expect(response.data, null);
+  });
+
+  test('#test forceConvert responseType', () async {
+    final dio = Dio(BaseOptions(
+      baseUrl: MockAdapter.mockBase,
+    )) //
+      ..httpClientAdapter = MockAdapter();
+    final expectedResponseData = <String, dynamic>{"code": 0, "result": "ok"};
+
+    final response = await dio.get<Map<String, dynamic>>('/test-force-convert');
+    expect(response.data, expectedResponseData);
+
+    final textResponse = await dio.get<dynamic>('/test-force-convert');
+    expect(textResponse.data, json.encode(expectedResponseData));
+
+    final textResponse2 = await dio.get<String>('/test-force-convert');
+    expect(textResponse2.data, json.encode(expectedResponseData));
   });
 }


### PR DESCRIPTION
> Picked from https://github.com/flutterchina/dio/pull/1490

### New Pull Request Checklist
* [x]  I have read the [Documentation](https://pub.dartlang.org/packages/dio)
* [x]  I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
* [x]  I have updated this branch with the latest `develop` to avoid conflicts (via merge from master or rebase)
* [x]  I have added the required tests to prove the fix/feature I am adding
* [ ]  I have updated the documentation (if necessary)
* [x]  I have run the tests and they pass

- The original code didn't pass the generic `T` down.
- `T` determines whether `forceConvert` is true. When `forceConvert` is true, it will force the response to be parsed as JSON.