### PR TITLE
Add .DS_Store file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ plugins/http2_adapter/.idea/
 plugins/http2_adapter/.exampl
 
 .vscode/
+
+# Miscellaneous
+.DS_Store


### PR DESCRIPTION
Ignores the macOS `.DS_Store` file. This file is really annoying when working on macOS.