### PR TITLE
Show `IOHttpClientAdapter`

### DIFF
--- a/dio/lib/io.dart
+++ b/dio/lib/io.dart
@@ -1,2 +1,3 @@
 export 'src/entry/dio_for_native.dart' show DioForNative;
-export 'src/adapters/io_adapter.dart' show DefaultHttpClientAdapter;
+export 'src/adapters/io_adapter.dart'
+    show DefaultHttpClientAdapter, IOHttpClientAdapter;


### PR DESCRIPTION
Signed-off-by: Alex Li <github@alexv525.com>

We've deprecated `DefaultHttpClientAdapter`, but not exported `IOHttpClientAdapter` from the library.
