### PR TITLE
Imply the default content type if capable

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 5.0.0-dev.2
+
+- Revert the removal of `setRequestContentTypeWhenNoPayload`
+  and provide better conditions for the default `content-type` header.
+
 ## 5.0.0-dev.1
 
 - Allow asynchronized method with `savePath`.
@@ -11,6 +16,7 @@
 
 ### Breaking Changes
 
+- Remove `BaseOptions.setRequestContentTypeWhenNoPayload`.
 - Improve `DioError`s. There are now more cases in which the inner original stacktrace is supplied.
 - `HttpClientAdapter` must now be implemented instead of extended.
 - Any classes specific to `dart:io` platforms can now be imported via `import 'package:diox/io.dart';`.

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -300,10 +300,14 @@ class Options {
 
     final headers = caseInsensitiveKeyMap(baseOpt.headers);
     headers.remove(Headers.contentTypeHeader);
-    if (this.headers != null) {
-      headers.addAll(this.headers!);
+    headers.addAll(this.headers ?? {});
+    // Imply the default content type if capable.
+    if (data != null ||
+        baseOpt.setRequestContentTypeWhenNoPayload && data == null) {
+      headers[Headers.contentTypeHeader] ??= Headers.jsonContentType;
     }
-    final String? contentType = this.headers?[Headers.contentTypeHeader];
+    final String? contentType =
+        headers[Headers.contentTypeHeader] ?? this.contentType;
     final extra = Map<String, dynamic>.from(baseOpt.extra);
     if (this.extra != null) {
       extra.addAll(this.extra!);

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -335,12 +335,11 @@ class Options {
       requestEncoder: requestEncoder ?? baseOpt.requestEncoder,
       responseDecoder: responseDecoder ?? baseOpt.responseDecoder,
       listFormat: listFormat ?? baseOpt.listFormat,
+      onReceiveProgress: onReceiveProgress,
+      onSendProgress: onSendProgress,
+      cancelToken: cancelToken,
+      contentType: contentType ?? this.contentType ?? baseOpt.contentType,
     );
-    requestOptions.onReceiveProgress = onReceiveProgress;
-    requestOptions.onSendProgress = onSendProgress;
-    requestOptions.cancelToken = cancelToken;
-    requestOptions.contentType =
-        contentType ?? this.contentType ?? baseOpt.contentType;
     return requestOptions;
   }
 
@@ -671,8 +670,8 @@ class _RequestConfig {
 
   set headers(Map<String, dynamic>? headers) {
     _headers = caseInsensitiveKeyMap(headers);
-    if (_defaultContentType != null &&
-        !_headers.containsKey(Headers.contentTypeHeader)) {
+    if (!_headers.containsKey(Headers.contentTypeHeader) &&
+        _defaultContentType != null) {
       _headers[Headers.contentTypeHeader] = _defaultContentType;
     }
   }
@@ -710,23 +709,24 @@ class _RequestConfig {
 
   Duration? _receiveTimeout;
 
-  /// The request Content-Type. The default value is [ContentType.json].
+  /// The request Content-Type. Defaults to [ContentType.json] if capable.
+  ///
   /// If you want to encode request body with 'application/x-www-form-urlencoded',
-  /// you can set `ContentType.parse('application/x-www-form-urlencoded')`, and [Dio]
-  /// will automatically encode the request body.
+  /// you can set `ContentType.parse('application/x-www-form-urlencoded')`,
+  /// and [Dio] will automatically encode the request body.
+  String? get contentType => _headers[Headers.contentTypeHeader] as String?;
+
   set contentType(String? contentType) {
-    if (contentType != null) {
-      _headers[Headers.contentTypeHeader] =
-          _defaultContentType = contentType.trim();
+    final newContentType = contentType?.trim();
+    _defaultContentType = newContentType;
+    if (newContentType != null) {
+      _headers[Headers.contentTypeHeader] = newContentType;
     } else {
-      _defaultContentType = null;
       _headers.remove(Headers.contentTypeHeader);
     }
   }
 
   String? _defaultContentType;
-
-  String? get contentType => _headers[Headers.contentTypeHeader] as String?;
 
   /// [responseType] indicates the type of data that the server will respond with
   /// options which defined in [ResponseType] are `json`, `stream`, `plain`.

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -172,8 +172,13 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     );
   }
 
-  /// If the value is `false`, `content-type` in request header will be null
-  /// by default until users explicitly define the corresponding value.
+  /// The option will try to imply the default `content-type` header value
+  /// if there is a payload in requests and if the header value not set.
+  ///
+  /// The `content-type` header value will be implied to
+  /// [Headers.jsonContentType] when:
+  /// - [RequestOptions.data] is null and the option is true.
+  /// - [RequestOptions.data] is not null.
   bool setRequestContentTypeWhenNoPayload;
 }
 

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -99,6 +99,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
+    this.setRequestContentTypeWhenNoPayload = false,
   })  : assert(connectTimeout == null || !connectTimeout.isNegative),
         assert(baseUrl.isEmpty || Uri.parse(baseUrl).host.isNotEmpty),
         super(
@@ -144,6 +145,7 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
     RequestEncoder? requestEncoder,
     ResponseDecoder? responseDecoder,
     ListFormat? listFormat,
+    bool? setRequestContentTypeWhenNoPayload,
   }) {
     return BaseOptions(
       method: method ?? this.method,
@@ -165,8 +167,14 @@ class BaseOptions extends _RequestConfig with OptionsMixin {
       requestEncoder: requestEncoder ?? this.requestEncoder,
       responseDecoder: responseDecoder ?? this.responseDecoder,
       listFormat: listFormat ?? this.listFormat,
+      setRequestContentTypeWhenNoPayload: setRequestContentTypeWhenNoPayload ??
+          this.setRequestContentTypeWhenNoPayload,
     );
   }
+
+  /// If the value is `false`, `content-type` in request header will be null
+  /// by default until users explicitly define the corresponding value.
+  bool setRequestContentTypeWhenNoPayload;
 }
 
 mixin OptionsMixin {

--- a/dio/migration_guide.md
+++ b/dio/migration_guide.md
@@ -17,8 +17,6 @@ When new content need to be added to the migration guide, make sure they're foll
 
 ### Summary
 
-- `BaseOptions.setRequestContentTypeWhenNoPayload` has been removed,
-  which will not imply `Content-Type` by default, and requests should explicitly define their content type.
 - `get` and `getUri` in `Dio` has different signature.
 - `DefaultHttpClientAdapter` is now named `IOHttpClientAdapter`,
   and the platform independent adapter can be initiated by `HttpClientAdapter()` which is a factory method.

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: diox
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
-version: 5.0.0-dev.1
+version: 5.0.0-dev.2
 homepage: https://github.com/cfug/diox
 repository: https://github.com/cfug/diox/blob/main/dio
 issue_tracker: https://github.com/cfug/diox/issues

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -163,17 +163,30 @@ void main() {
       //
     }
 
-    assert(Options(contentType: contentTypeJson).compose(bo1, '').contentType ==
-        contentTypeJson);
-
-    assert(Options(contentType: contentTypeJson).compose(bo2, '').contentType ==
-        contentTypeJson);
-
-    assert(Options(headers: jsonHeaders).compose(bo1, '').contentType ==
-        contentTypeJson);
-
-    assert(Options(headers: jsonHeaders).compose(bo2, '').contentType ==
-        contentTypeJson);
+    expect(
+      Options(contentType: contentTypeJson).compose(bo1, '').contentType,
+      contentTypeJson,
+    );
+    expect(
+      Options(contentType: contentTypeJson).compose(bo2, '').contentType,
+      contentTypeJson,
+    );
+    expect(
+      Options(contentType: contentTypeJson).compose(bo3, '').contentType,
+      contentTypeJson,
+    );
+    expect(
+      Options(headers: jsonHeaders).compose(bo1, '').contentType,
+      contentTypeJson,
+    );
+    expect(
+      Options(headers: jsonHeaders).compose(bo2, '').contentType,
+      contentTypeJson,
+    );
+    expect(
+      Options(headers: jsonHeaders).compose(bo3, '').contentType,
+      contentTypeJson,
+    );
 
     /// RequestOptions
     try {
@@ -226,9 +239,9 @@ void main() {
 
     final r3 = await dio.get(
       '',
-      options: Options(headers: {
-        Headers.contentTypeHeader: Headers.jsonContentType,
-      }),
+      options: Options(
+        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+      ),
     );
     expect(
       r3.requestOptions.headers[Headers.contentTypeHeader],
@@ -238,12 +251,13 @@ void main() {
     final r4 = await dio.post('', data: '');
     expect(
       r4.requestOptions.headers[Headers.contentTypeHeader],
-      null,
+      Headers.jsonContentType,
     );
   });
 
   test('#test default content-type 2', () async {
     final dio = Dio();
+    dio.options.setRequestContentTypeWhenNoPayload = true;
     dio.options.baseUrl = 'https://www.example.com';
 
     final r1 = Options(method: 'GET').compose(dio.options, '/test').copyWith(
@@ -267,6 +281,7 @@ void main() {
       );
       assert(false);
     } catch (_) {}
+    dio.options.setRequestContentTypeWhenNoPayload = false;
 
     final r3 = Options(method: 'GET').compose(dio.options, '/test');
     assert(r3.uri.toString() == 'https://www.example.com/test');

--- a/dio/test/request_test.dart
+++ b/dio/test/request_test.dart
@@ -17,7 +17,6 @@ void main() {
       dio = Dio();
       dio.options
         ..baseUrl = serverUrl.toString()
-        ..contentType = Headers.jsonContentType
         ..connectTimeout = Duration(seconds: 1)
         ..receiveTimeout = Duration(seconds: 5)
         ..headers = {'User-Agent': 'dartisan'};


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->

Reverts part of #32, and also adds better conditions when implying the default content type header.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/diox/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/diox/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->

#32 hurts when the change comes to production apps. To migrate with that change, a default `content-type` header value must be specified, which is too breakable even though we have multiple BCs.
But #32 solves the problem that some request methods do not allow to have payload during their requests.
So, in this PR, a more precise workflow and conditions are updated. Instead of setting the default value in the base option, we can do the final check in the composing of options.