### PR TITLE
Fix DioErrorType.other to DioErrorType.unknown in docs comment

### DIFF
--- a/dio/README.md
+++ b/dio/README.md
@@ -554,11 +554,11 @@ Response? response;
 DioErrorType type;
 
 /// The original error/exception object;
-/// It's usually not null when `type` is [DioErrorType.other].
+/// It's usually not null when `type` is [DioErrorType.unknown].
 Object? error;
 
 /// The stacktrace of the original error/exception object;
-/// It's usually not null when `type` is [DioErrorType.other].
+/// It's usually not null when `type` is [DioErrorType.unknown].
 StackTrace? stackTrace;
 
 /// The error message that throws a [DioError].

--- a/dio/lib/src/dio_error.dart
+++ b/dio/lib/src/dio_error.dart
@@ -139,11 +139,11 @@ class DioError {
   final DioErrorType type;
 
   /// The original error/exception object;
-  /// It's usually not null when `type` is [DioErrorType.other].
+  /// It's usually not null when `type` is [DioErrorType.unknown].
   final Object? error;
 
   /// The stacktrace of the original error/exception object;
-  /// It's usually not null when `type` is [DioErrorType.other].
+  /// It's usually not null when `type` is [DioErrorType.unknown].
   final StackTrace? stackTrace;
 
   /// The error message that throws a [DioError].


### PR DESCRIPTION
DioErrorType.other is renamed to DioErrorType.unknown, but is not modified in the comment document

