### PR TITLE
🚑️ Inherit `content-type` from options first

### DIFF
--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 5.0.0-dev.3
+
+- Inherit `content-type` from `Options` first.
+
 ## 5.0.0-dev.2
 
 - Revert the removal of `setRequestContentTypeWhenNoPayload`

--- a/dio/lib/src/options.dart
+++ b/dio/lib/src/options.dart
@@ -304,15 +304,19 @@ class Options {
     if (queryParameters != null) query.addAll(queryParameters);
 
     final headers = caseInsensitiveKeyMap(baseOpt.headers);
-    headers.remove(Headers.contentTypeHeader);
-    headers.addAll(this.headers ?? {});
+    if (this.headers != null) {
+      headers.addAll(this.headers!);
+    }
+    if (this.contentType != null) {
+      headers[Headers.contentTypeHeader] = this.contentType;
+    }
     // Imply the default content type if capable.
-    if (data != null ||
-        baseOpt.setRequestContentTypeWhenNoPayload && data == null) {
+    // This is a historical issue that dio used to imply the json type, it'll be
+    // too breaking to let user apply a base content type at the moment.
+    if (data != null || baseOpt.setRequestContentTypeWhenNoPayload) {
       headers[Headers.contentTypeHeader] ??= Headers.jsonContentType;
     }
-    final String? contentType =
-        headers[Headers.contentTypeHeader] ?? this.contentType;
+    final String? contentType = headers[Headers.contentTypeHeader];
     final extra = Map<String, dynamic>.from(baseOpt.extra);
     if (this.extra != null) {
       extra.addAll(this.extra!);

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -1,6 +1,6 @@
 name: diox
 description: A powerful Http client for Dart, which supports Interceptors, FormData, Request Cancellation, File Downloading, Timeout etc.
-version: 5.0.0-dev.2
+version: 5.0.0-dev.3
 homepage: https://github.com/cfug/diox
 repository: https://github.com/cfug/diox/blob/main/dio
 issue_tracker: https://github.com/cfug/diox/issues

--- a/dio/test/options_test.dart
+++ b/dio/test/options_test.dart
@@ -253,6 +253,61 @@ void main() {
       r4.requestOptions.headers[Headers.contentTypeHeader],
       Headers.jsonContentType,
     );
+
+    final r5 = await dio.get(
+      '',
+      options: Options(
+        // Final result should respect this.
+        contentType: Headers.textPlainContentType,
+        // Rather than this.
+        headers: {Headers.contentTypeHeader: Headers.formUrlEncodedContentType},
+      ),
+    );
+    expect(
+      r5.requestOptions.headers[Headers.contentTypeHeader],
+      Headers.textPlainContentType,
+    );
+
+    final r6 = await dio.get(
+      '',
+      data: '',
+      options: Options(
+        contentType: Headers.formUrlEncodedContentType,
+        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+      ),
+    );
+    expect(
+      r6.requestOptions.headers[Headers.contentTypeHeader],
+      Headers.formUrlEncodedContentType,
+    );
+
+    // Update the base option.
+    dio.options.contentType = Headers.textPlainContentType;
+    final r7 = await dio.get('');
+    expect(
+      r7.requestOptions.headers[Headers.contentTypeHeader],
+      Headers.textPlainContentType,
+    );
+
+    final r8 = await dio.get(
+      '',
+      options: Options(contentType: Headers.jsonContentType),
+    );
+    expect(
+      r8.requestOptions.headers[Headers.contentTypeHeader],
+      Headers.jsonContentType,
+    );
+
+    final r9 = await dio.get(
+      '',
+      options: Options(
+        headers: {Headers.contentTypeHeader: Headers.jsonContentType},
+      ),
+    );
+    expect(
+      r9.requestOptions.headers[Headers.contentTypeHeader],
+      Headers.jsonContentType,
+    );
   });
 
   test('#test default content-type 2', () async {


### PR DESCRIPTION
Fix the regression of `content-type` that is brought from #46.

### New Pull Request Checklist

- [x] I have read the [Documentation](https://pub.dev/documentation/diox/latest/)
- [x] I have searched for a similar pull request in the [project](https://github.com/cfug/diox/pulls) and found none
- [x] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I'm adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests without failures

### Additional context and info (if any)

The proper order to determine which `content-type` should be used is:
1. `Options.headers['content-type']`
2. `Options.contentType`
3. `BaseOptions.contentType`
4. `Headers.jsonContentType`

And after #46, it's been changed to:
1. `Options.headers['content-type']`
2. `Options.contentType`
3. `Headers.jsonContentType`

Which dropped the content type set in the `BaseOptions`.