### PR TITLE
Raise min Dart SDK to 2.15.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, beta ]
+        sdk: [ 2.15.0, stable, beta ]
         platform: [ vm, chrome ]
     steps:
       - uses: actions/checkout@v3
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, beta ]
+        sdk: [ 2.15.0, stable, beta ]
         directory: ["plugins/cookie_manager", "plugins/http2_adapter"]
     steps:
       - uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ stable, beta ]
+        channel: [ min, stable, beta ]
         directory: ["plugins/native_diox_adapter"]
     defaults:
       run:
@@ -139,7 +139,8 @@ jobs:
         uses: subosito/flutter-action@v2.8.0
         with:
           cache: true
-          channel: ${{ matrix.channel }}
+          flutter-version: ${{ matrix.channel == 'min' && '3.3.0' || '' }}
+          channel: ${{ matrix.channel == 'min' && 'stable' || matrix.channel }}
       - run: flutter test
 
   build_example_android:

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Raise Min Dart SDK version to 2.15.0 to support `BackgroundTransformer`
+- Raise the min Dart SDK version to 2.15.0 to support `BackgroundTransformer`.
 
 ## 5.0.0
 

--- a/dio/CHANGELOG.md
+++ b/dio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Raise Min Dart SDK version to 2.15.0 to support `BackgroundTransformer`
+
 ## 5.0.0
 
 - Change `Dio.transformer` from `DefaultTransformer` to `BackgroundTransformer`.

--- a/dio/pubspec.yaml
+++ b/dio/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/cfug/diox/issues
 version: 5.0.0
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   http_parser: ^4.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.1 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   cookie_jar:

--- a/example_flutter_app/pubspec.yaml
+++ b/example_flutter_app/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.1 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/plugins/cookie_manager/pubspec.yaml
+++ b/plugins/cookie_manager/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/diox/blob/main/plugins/cookie_manager
 issue_tracker: https://github.com/cfug/diox/issues
 
 environment:
-  sdk: '>=2.12.1 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   cookie_jar: ^3.0.0

--- a/plugins/http2_adapter/lib/src/http2_adapter.dart
+++ b/plugins/http2_adapter/lib/src/http2_adapter.dart
@@ -84,7 +84,7 @@ class Http2Adapter implements HttpClientAdapter {
     List<Uint8List>? list;
     final hasRequestData = requestStream != null;
     if (!excludeMethods.contains(options.method) && hasRequestData) {
-      list = await requestStream!.toList();
+      list = await requestStream.toList();
       requestStream = Stream.fromIterable(list);
     }
 

--- a/plugins/http2_adapter/pubspec.yaml
+++ b/plugins/http2_adapter/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/cfug/diox/blob/main/plugins/http2_adapter
 issue_tracker: https://github.com/cfug/diox/issues
 
 environment:
-  sdk: '>=2.12.1 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   http2: ^2.0.0


### PR DESCRIPTION
<!-- Write down your pull request descriptions. -->
The new `BackgroundTransformer` uses `Isolate.exit` which was added in Dart 2.15.0.
This PR raises the min SDK level on the main packages and all plugins.


### New Pull Request Checklist

- [ ] I have read the [Documentation](https://pub.dev/documentation/diox/latest/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/cfug/diox/pulls) and found none
- [ ] I have updated this branch with the latest `main` branch to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I'm adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests without failures

### Additional context and info (if any)

<!-- Provide more context and info about the PR. -->
